### PR TITLE
인증이 필요없는 URI에서 토큰 검증을 하는 버그

### DIFF
--- a/src/main/java/com/leesh/quiz/global/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/leesh/quiz/global/configuration/SecurityConfiguration.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -22,7 +21,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+import static com.leesh.quiz.global.util.RequestMatchersUtils.getPermitAllRequestMatchers;
 import static org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder;
 
 @Slf4j
@@ -70,11 +69,7 @@ public class SecurityConfiguration {
 
                 // 인증이 필요 없는 API
                 .authorizeHttpRequests()
-                .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-                .permitAll()
-                .requestMatchers(toH2Console())
-                .permitAll()
-                .requestMatchers("/api/oauth2/**", "/api/health")
+                .requestMatchers(getPermitAllRequestMatchers())
                 .permitAll()
 
                 // 그 외 모두 인증 필요

--- a/src/main/java/com/leesh/quiz/global/error/ErrorCode.java
+++ b/src/main/java/com/leesh/quiz/global/error/ErrorCode.java
@@ -3,25 +3,31 @@ package com.leesh.quiz.global.error;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
 @Getter
 public enum ErrorCode {
 
-    /* Token */
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A-001", "토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A-002", "토큰이 유효하지 않습니다."),
+    /* Authentication */
+    EXPIRED_TOKEN(UNAUTHORIZED, "A-001", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(UNAUTHORIZED, "A-002", "토큰이 유효하지 않습니다."),
 
-    INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "A-003", "올바르지 않은 Authorization 헤더입니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "A-004", "리프레시 토큰이 존재하지 않습니다."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A-005", "리프레시 토큰이 만료되었습니다."),
+    INVALID_AUTHORIZATION_HEADER(UNAUTHORIZED, "A-003", "올바르지 않은 Authorization 헤더입니다."),
+    NOT_EXIST_AUTHORIZATION(UNAUTHORIZED, "A-004", "Authorization 헤더가 존재하지 않습니다."),
+    NOT_BEARER_TYPE_AUTHORIZATION(UNAUTHORIZED, "A-005", "Bearer 타입의 Authorization 헤더가 아닙니다."),
+    ACCESS_TOKEN_NOT_FOUND(UNAUTHORIZED, "A-006", "접근 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(UNAUTHORIZED, "A-006", "리프레시 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, "A-007", "리프레시 토큰이 만료되었습니다."),
 
     /* Oauth2 */
-    NOT_SUPPORT_OAUTH2_TYPE(HttpStatus.BAD_REQUEST, "O-001", "지원하지 않는 Oauth2 타입입니다."),
-    ALREADY_REGISTERED_FROM_KAKAO(HttpStatus.BAD_REQUEST, "O-002", "카카오 소셜 계정으로 이미 가입된 이메일 입니다."),
-    ALREADY_REGISTERED_FROM_GOOGLE(HttpStatus.BAD_REQUEST, "O-003", "구글 소셜 계정으로 이미 가입된 이메일 입니다."),
-    ALREADY_REGISTERED_FROM_NAVER(HttpStatus.BAD_REQUEST, "O-004", "네이버 소셜 계정으로 이미 가입된 이메일 입니다."),
+    NOT_SUPPORT_OAUTH2_TYPE(BAD_REQUEST, "O-001", "지원하지 않는 Oauth2 타입입니다."),
+    ALREADY_REGISTERED_FROM_KAKAO(BAD_REQUEST, "O-002", "카카오 소셜 계정으로 이미 가입된 이메일 입니다."),
+    ALREADY_REGISTERED_FROM_GOOGLE(BAD_REQUEST, "O-003", "구글 소셜 계정으로 이미 가입된 이메일 입니다."),
+    ALREADY_REGISTERED_FROM_NAVER(BAD_REQUEST, "O-004", "네이버 소셜 계정으로 이미 가입된 이메일 입니다."),
 
     /* User */
-    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "M-001", "이미 존재하는 이메일 입니다."),
+    DUPLICATED_EMAIL(BAD_REQUEST, "M-001", "이미 존재하는 이메일 입니다."),
     ;
 
     private final HttpStatus httpStatus;
@@ -41,4 +47,4 @@ public enum ErrorCode {
         this.message = message;
         this.parameter = parameter;
     }
-}
+    }

--- a/src/main/java/com/leesh/quiz/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/leesh/quiz/global/error/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.leesh.quiz.global.error;
 
-import com.leesh.quiz.global.error.exception.ExternalException;
 import com.leesh.quiz.global.error.exception.BusinessException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/leesh/quiz/global/jwt/constant/GrantType.java
+++ b/src/main/java/com/leesh/quiz/global/jwt/constant/GrantType.java
@@ -11,6 +11,10 @@ public enum GrantType {
         this.type = type;
     }
 
-    private String type;
+    private final String type;
+
+    public static boolean isBearerType(String type) {
+        return GrantType.BEARER.type.equals(type);
+    }
 
 }

--- a/src/main/java/com/leesh/quiz/global/util/RequestMatchersUtils.java
+++ b/src/main/java/com/leesh/quiz/global/util/RequestMatchersUtils.java
@@ -1,0 +1,22 @@
+package com.leesh.quiz.global.util;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
+
+public abstract class RequestMatchersUtils {
+
+    private static final RequestMatcher[] permitAllRequestMatchers = new RequestMatcher[]{
+            new AntPathRequestMatcher("/api/oauth2/**"),
+            new AntPathRequestMatcher("/api/health"),
+            toH2Console(),
+            PathRequest.toStaticResources().atCommonLocations()
+    };
+
+    public static RequestMatcher[] getPermitAllRequestMatchers() {
+        return permitAllRequestMatchers;
+    }
+
+}


### PR DESCRIPTION
- 필터에서 인증이 필요 없는 URL 인지 체크한 뒤 다음 필터로 넘겨주는 방식으로 버그 수정하였습니다.

- ** 이 방법은, 새로운 권한 체크가 필요없는 URL이 발생할 경우 필터 이외에도 스프링 시큐리티의 PermitALL()도 수정이 필요합니다. RequestMatchersUtils 클래스를 이용하여 해당 부분만 수정하도록 하였지만, 누군가 의도적으로 스프링 시큐리티의 PermitALL() 메서드에 다른 URL을 추가시 필터와 다르게 동작할 수 있습니다.

스프링 시큐리티와 필터를 동시에 사용하면서 해당 버그를 해결할 수 있는 방법은 현재까지는 이것이 최선인 것 같습니다.