### PR TITLE
서버 에러가 클라이언트에 그대로 노출되는 버그

### DIFF
--- a/src/main/java/com/leesh/quiz/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/leesh/quiz/global/error/GlobalExceptionHandler.java
@@ -87,7 +87,7 @@ public class GlobalExceptionHandler {
 
         ErrorCode errorCode = ErrorCode.INTERNAL_ERROR;
 
-        var body = ErrorResponse.of(errorCode.getCode(), e.getMessage());
+        var body = ErrorResponse.of(errorCode.getCode(), errorCode.getMessage());
 
         return ResponseEntity.status(errorCode.getHttpStatus()).body(body);
     }


### PR DESCRIPTION
문제 원인 : 에러 메세지를 응답으로 내려주지 않아서 생긴 현상

해결 방법 : 에러 응답 시, Respone Body에 에러 메세지를 적용시켜 주었습니다.