### PR TITLE
회원 탈퇴 후, 다른 소셜 공급자로 회원가입 하는 경우 버그 발생

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,17 @@ spring:
 #  sql:
 #    init:
 #      mode: always
+
+oauth2:
+  kakao:
+    client-id: ENC(+qwXTMtp0ldynQquCCT5E3saeJ8wGyZt8qc8oErTQfidIU/k68jpHgyUbr/Z6vSD)
+    client-secret: ENC(/Ti7JS3XCc9dXqianikAXLkVnYW62cdrgd5MP6VpxuSkuSOKK5BRnwJBu+yMcRPK)
+    redirect-uri: ENC(Q/xHiaIH9MdG3SZ1V+8TN0kurPNNm8zZgBzCNHyv4bcI5M1O+rYS/hmR9yyj5zvq+aeQibnYKSI=)
+  google:
+    client-id: ENC(RbSPR65Q5gbvHn6v8qCjOjbo/rPoU/iVZAWx1o0O6JCWzWfs54JLBkV4i7/OOY0pSY1MY9gSb6abUdL2kJ5pzovFCYZ3H8QBnwOGmLLehUFaNs3N4cSGyA==)
+    client-secret: ENC(3tgUQVepvdHtsXkzm+yGtAFh/X6Wf8l7N0bcODBW5FyPxfG+T203zdzEYFLtE8FS)
+    redirect-uri: ENC(Q/TUiycA/lXt2zV+1JJb7zp1Ct518DxL6uaX8eXi8opWaMtamiHN3c0d9OWrWv0az5tttfslkJ0=)
+  naver:
+    client-id: ENC(T9U9GbshI2M2rxHtb0q1szQ1gWYsaN/z2aDhwabsSOw=)
+    client-secret: ENC(rosNjvu/3I1sS9RkH1WlG/dA/JlS5Kgk)
+    redirect-uri: ENC(CZZFpqwoEZqTXGqOuejBFSENIQaz1bkBGMMPlShljzyP45fLu9O+EbWWAo5QcRtZfdnDIMOgVQ4=)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,17 @@ logging:
         SQL: warn
         type.descriptor.sql.BasicBinder: warn
         com.leesh: warn
+
+oauth2:
+  kakao:
+    client-id: ENC(+qwXTMtp0ldynQquCCT5E3saeJ8wGyZt8qc8oErTQfidIU/k68jpHgyUbr/Z6vSD)
+    client-secret: ENC(/Ti7JS3XCc9dXqianikAXLkVnYW62cdrgd5MP6VpxuSkuSOKK5BRnwJBu+yMcRPK)
+    redirect-uri: ENC(4Zg4YUEW+LzOewjfdwVW0bppr6uJ6X8JQtKj5K7j/PXptC4VTS0AVjmRNYyZ5Oaij/CAIYkrNik=)
+  google:
+    client-id: ENC(RbSPR65Q5gbvHn6v8qCjOjbo/rPoU/iVZAWx1o0O6JCWzWfs54JLBkV4i7/OOY0pSY1MY9gSb6abUdL2kJ5pzovFCYZ3H8QBnwOGmLLehUFaNs3N4cSGyA==)
+    client-secret: ENC(3tgUQVepvdHtsXkzm+yGtAFh/X6Wf8l7N0bcODBW5FyPxfG+T203zdzEYFLtE8FS)
+    redirect-uri: ENC(GgtjtBX7wmi16BzD4g0zaevr7gFDlDayLh4iR+ShTQFGHZ9tG/yK9EDdcoUn1kVZFTb7baG1B+E=)
+  naver:
+    client-id: ENC(T9U9GbshI2M2rxHtb0q1szQ1gWYsaN/z2aDhwabsSOw=)
+    client-secret: ENC(rosNjvu/3I1sS9RkH1WlG/dA/JlS5Kgk)
+    redirect-uri: ENC(/YFX705itbg+Ldt9EfMfmSnRT5JKopFmD6f4vPAg4INFNtK/zH9kE6ORlgifKBrGQET4vDmICu4=)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,20 +41,6 @@ token:
   access-token-expiration-time: 10000  # 15분 : 1000(ms) x 60(s) x 15(m)
   refresh-token-expiration-time: 1209600000 # 2주 : 1000(ms) x 60 (s) x 60(m) x 24(h) x 14(d)
 
-oauth2:
-  kakao:
-    client-id: ENC(+qwXTMtp0ldynQquCCT5E3saeJ8wGyZt8qc8oErTQfidIU/k68jpHgyUbr/Z6vSD)
-    client-secret: ENC(/Ti7JS3XCc9dXqianikAXLkVnYW62cdrgd5MP6VpxuSkuSOKK5BRnwJBu+yMcRPK)
-    redirect-uri: ENC(4Zg4YUEW+LzOewjfdwVW0bppr6uJ6X8JQtKj5K7j/PXptC4VTS0AVjmRNYyZ5Oaij/CAIYkrNik=)
-  google:
-    client-id: ENC(RbSPR65Q5gbvHn6v8qCjOjbo/rPoU/iVZAWx1o0O6JCWzWfs54JLBkV4i7/OOY0pSY1MY9gSb6abUdL2kJ5pzovFCYZ3H8QBnwOGmLLehUFaNs3N4cSGyA==)
-    client-secret: ENC(3tgUQVepvdHtsXkzm+yGtAFh/X6Wf8l7N0bcODBW5FyPxfG+T203zdzEYFLtE8FS)
-    redirect-uri: ENC(GgtjtBX7wmi16BzD4g0zaevr7gFDlDayLh4iR+ShTQFGHZ9tG/yK9EDdcoUn1kVZFTb7baG1B+E=)
-  naver:
-    client-id: ENC(T9U9GbshI2M2rxHtb0q1szQ1gWYsaN/z2aDhwabsSOw=)
-    client-secret: ENC(rosNjvu/3I1sS9RkH1WlG/dA/JlS5Kgk)
-    redirect-uri: ENC(/YFX705itbg+Ldt9EfMfmSnRT5JKopFmD6f4vPAg4INFNtK/zH9kE6ORlgifKBrGQET4vDmICu4=)
-
 jasypt:
   encryptor:
     password: ${PASSWORD}


### PR DESCRIPTION
발생 원인 : 최초 네이버로 회원 가입을 한 유저가 회원 탈퇴 시, `deleted` 필드가 true로 변경됩니다. 그 후, 카카오로 다시 회원 가입을 하는 경우 만약 카카오와 네이버의 이메일이 서로 같다면 이미 회원 탈퇴한 유저라 하더라도 validation 로직이 수행되어 에러가 발생합니다.

해결 : 이메일이 서로 같으면서 다른 Oauth2 공급업체를 통해 재가입을 하는 경우에 기존의 Oauth2 공급 업체를 갱신시켜주는 로직을 추가하였습니다.