### PR TITLE
소셜 회원가입 시 최초 닉네임을 유저 이름이 아닌 이메일로 하기

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ EXPOSE 8080
 ENV PROFILE prod
 ENV JASYPT_PASSWORD ""
 
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=${PROFILE}", "-Djasypt.encryptor.passowrd=${JASYPT_PASSWORD}", "/app/quiz-api-server.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=${PROFILE}", "-Djasypt.encryptor.password=${JASYPT_PASSWORD}", "/app/quiz-api-server.jar"]

--- a/src/main/java/com/leesh/quiz/external/oauth2/Oauth2Attributes.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/Oauth2Attributes.java
@@ -14,16 +14,4 @@ public interface Oauth2Attributes {
 
     Oauth2Type getOauth2Type();
 
-    default User toEntity() {
-
-        // 소셜 로그인을 통해 생성된 유저는 기본 권한을 USER로 가진다.
-        return User.builder()
-                .username(getName())
-                .email(getEmail())
-                .role(Role.USER)
-                .oauth2Type(getOauth2Type())
-                .profile(getProfile())
-                .build();
-    }
-
 }

--- a/src/main/java/com/leesh/quiz/external/oauth2/google/client/GoogleApiClient.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/google/client/GoogleApiClient.java
@@ -1,6 +1,6 @@
 package com.leesh.quiz.external.oauth2.google.client;
 
-import com.leesh.quiz.external.oauth2.google.dto.GoogleUserInfoResponseDto;
+import com.leesh.quiz.external.oauth2.google.dto.GoogleUserInfoDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface GoogleApiClient {
 
     @PostMapping(value = "/userinfo?access_token={accessToken}", consumes = "application/json")
-    GoogleUserInfoResponseDto getUserInfo(@RequestHeader("Content-type") String contentType,
-                                          @PathVariable("accessToken") String accessToken);
+    GoogleUserInfoDto getUserInfo(@RequestHeader("Content-type") String contentType,
+                                  @PathVariable("accessToken") String accessToken);
 
 }

--- a/src/main/java/com/leesh/quiz/external/oauth2/google/dto/GoogleUserInfoDto.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/google/dto/GoogleUserInfoDto.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.leesh.quiz.domain.user.constant.Oauth2Type;
 import com.leesh.quiz.external.oauth2.Oauth2Attributes;
 
-public record GoogleUserInfoResponseDto(String name,
-                                        String email,
-                                        @JsonProperty("picture") String picture
+public record GoogleUserInfoDto(String name,
+                                String email,
+                                @JsonProperty("picture") String picture
                              ) implements Oauth2Attributes {
 
     @Override
     public String getName() {
-        return name;
+        return email.split("@")[0];
     }
 
     @Override

--- a/src/main/java/com/leesh/quiz/external/oauth2/kakao/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/kakao/dto/KakaoUserInfoDto.java
@@ -28,7 +28,7 @@ public record KakaoUserInfoDto(String id,
 
     @Override
     public String getProfile() {
-        return kakaoAccount.profile.thumbnailImageUrl;
+        return kakaoAccount.profile != null ? kakaoAccount.profile.thumbnailImageUrl : null;
     }
 
     @Override

--- a/src/main/java/com/leesh/quiz/external/oauth2/kakao/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/kakao/dto/KakaoUserInfoDto.java
@@ -18,13 +18,12 @@ public record KakaoUserInfoDto(String id,
 
     @Override
     public String getName() {
-        return kakaoAccount.profile.nickname;
+        return !StringUtils.hasText(kakaoAccount.email) ? id : kakaoAccount.email.split("@")[0];
     }
 
     @Override
     public String getEmail() {
-        return !StringUtils.hasText(kakaoAccount.email) ?
-                id : kakaoAccount.email;
+        return !StringUtils.hasText(kakaoAccount.email) ? id : kakaoAccount.email;
     }
 
     @Override

--- a/src/main/java/com/leesh/quiz/external/oauth2/naver/dto/NaverUserInfoDto.java
+++ b/src/main/java/com/leesh/quiz/external/oauth2/naver/dto/NaverUserInfoDto.java
@@ -15,7 +15,7 @@ public record NaverUserInfoDto(@JsonProperty("result_code")
 
     @Override
     public String getName() {
-        return response.name;
+        return response.email.split("@")[0];
     }
 
     @Override


### PR DESCRIPTION
Oauth2 제공업체로 부터 제공받은 이메일 중 `@`를 기준으로 앞 부분을 기본 닉네임으로 설정하도록 하였습니다.